### PR TITLE
Multiple recipients

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -6,6 +6,7 @@ return [
         'value' => env('SAVING_QUOTE_EXPIRE_VALUE', 7),
         'grace_period' => env('SAVING_QUOTE_EXPIRE_GRACE_PERIOD', 0),
     ],
+    'max_additional_emails' => env('SAVING_QUOTE_MAX_ADDITIONAL_EMAILS', 4),
     'mailable' => null, // Class name of the mailable to send after a quote is saved.
     'validator' => null,
 ];

--- a/database/migrations/2026_07_28_000000_add_additional_emails_to_quote_progresses.php
+++ b/database/migrations/2026_07_28_000000_add_additional_emails_to_quote_progresses.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('quote_progresses', function (Blueprint $table) {
+            $table->json('additional_emails')->nullable()->after('email');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('quote_progresses', function (Blueprint $table) {
+            $table->dropColumn('additional_emails');
+        });
+    }
+};

--- a/src/Http/Controllers/QuoteProgressController.php
+++ b/src/Http/Controllers/QuoteProgressController.php
@@ -49,7 +49,7 @@ class QuoteProgressController extends BaseController
         $request->validate([
             'email' => ['required', 'email'],
             'additionalEmails' => ['sometimes', 'array', 'max:'.config('saving-quote.max_additional_emails')],
-            'additionalEmails.*' => ['required', 'email', 'distinct'],
+            'additionalEmails.*' => ['required', 'email', 'distinct', 'different:email'],
             'data' => ['required', 'array'],
             ...$validator->rules($request->all()),
         ]);

--- a/src/Http/Controllers/QuoteProgressController.php
+++ b/src/Http/Controllers/QuoteProgressController.php
@@ -48,6 +48,8 @@ class QuoteProgressController extends BaseController
 
         $request->validate([
             'email' => ['required', 'email'],
+            'additionalEmails' => ['sometimes', 'array', 'max:'.config('saving-quote.max_additional_emails')],
+            'additionalEmails.*' => ['required', 'email', 'distinct'],
             'data' => ['required', 'array'],
             ...$validator->rules($request->all()),
         ]);

--- a/src/Http/Resources/QuoteResource.php
+++ b/src/Http/Resources/QuoteResource.php
@@ -19,7 +19,10 @@ class QuoteResource extends JsonResource
     {
         return [
             'email' => $this->email,
-            'data' => $this->data,
+            'data' => [
+                ...$this->data,
+                'additionalEmails' => $this->additional_emails ?? [],
+            ],
         ];
     }
 }

--- a/src/Models/QuoteProgress.php
+++ b/src/Models/QuoteProgress.php
@@ -17,6 +17,7 @@ use Illuminate\Database\Eloquent\Model;
  *
  * @property string $id
  * @property string $email
+ * @property array<int, string>|null $additional_emails
  * @property array<string, mixed> $data
  * @property DateTime $expire_at
  * @property DateTime|null $opened_at
@@ -32,6 +33,7 @@ use Illuminate\Database\Eloquent\Model;
  * @method static Builder|QuoteProgress whereCreatedAt($value)
  * @method static Builder|QuoteProgress whereData($value)
  * @method static Builder|QuoteProgress whereEmail($value)
+ * @method static Builder|QuoteProgress whereAdditionalEmails($value)
  * @method static Builder|QuoteProgress whereExpireAt($value)
  * @method static Builder|QuoteProgress whereId($value)
  * @method static Builder|QuoteProgress whereOpenedAt($value)
@@ -45,6 +47,7 @@ class QuoteProgress extends Model
 
     protected $fillable = [
         'email',
+        'additional_emails',
         'data',
         'expire_at',
         'opened_at',
@@ -52,6 +55,7 @@ class QuoteProgress extends Model
 
     /** @var array<string, string> */
     protected $casts = [
+        'additional_emails' => 'array',
         'data' => 'array',
         'expire_at' => 'datetime',
         'opened_at' => 'datetime',

--- a/src/Service/QuoteProgressService.php
+++ b/src/Service/QuoteProgressService.php
@@ -17,12 +17,14 @@ class QuoteProgressService
     public function create(array $data): QuoteProgress
     {
         $data['expire_at'] = Carbon::now()->add($this->expireUnit, $this->expireValue);
+        $data['additional_emails'] = $data['additionalEmails'] ?? null;
 
         $quoteProgress = new QuoteProgress($data);
         $quoteProgress->save();
 
         if (isset($this->mailable)) {
-            Mail::to($data['email'])->queue($this->mailable->setQuoteProgress($quoteProgress));
+            $recipients = array_merge([$data['email']], $data['additionalEmails'] ?? []);
+            Mail::to($recipients)->queue($this->mailable->setQuoteProgress($quoteProgress));
         }
 
         return $quoteProgress;

--- a/src/Service/QuoteProgressService.php
+++ b/src/Service/QuoteProgressService.php
@@ -12,18 +12,23 @@ class QuoteProgressService
     public function __construct(private readonly string $expireUnit, private readonly int $expireValue, private ?QuoteProgressAwareMailable $mailable = null) {}
 
     /**
-     * @param  array<array-key,string>  $data
+     * @param  array<string, mixed>  $data
      */
     public function create(array $data): QuoteProgress
     {
+        $additionalEmails = $data['additionalEmails'] ?? null;
+        if (! is_array($additionalEmails)) {
+            $additionalEmails = null;
+        }
+
         $data['expire_at'] = Carbon::now()->add($this->expireUnit, $this->expireValue);
-        $data['additional_emails'] = $data['additionalEmails'] ?? null;
+        $data['additional_emails'] = $additionalEmails;
 
         $quoteProgress = new QuoteProgress($data);
         $quoteProgress->save();
 
         if (isset($this->mailable)) {
-            $recipients = array_merge([$data['email']], $data['additionalEmails'] ?? []);
+            $recipients = array_merge([$data['email']], $additionalEmails ?? []);
             Mail::to($recipients)->queue($this->mailable->setQuoteProgress($quoteProgress));
         }
 

--- a/tests/Feature/Http/QuoteProgressControllerTest.php
+++ b/tests/Feature/Http/QuoteProgressControllerTest.php
@@ -73,6 +73,59 @@ class QuoteProgressControllerTest extends SavingQuoteTestCase
             ->assertStatus(422);
     }
 
+    public function test_create_quote_progress_with_additional_emails(): void
+    {
+        $this->postJson(route(RouteNames::CREATE_QUOTE_PROGRESS, [
+            'email' => 'daryna@jauntin.com',
+            'additionalEmails' => ['second@jauntin.com', 'third@jauntin.com'],
+            'data' => ['excludedActivities' => true, 'averageDailyAttendance' => 40],
+        ], false), ['Accept' => 'application/json'])
+            ->assertStatus(201)
+            ->assertJson([
+                'email' => 'daryna@jauntin.com',
+                'data' => ['additionalEmails' => ['second@jauntin.com', 'third@jauntin.com']],
+            ]);
+    }
+
+    public function test_create_quote_progress_without_additional_emails_still_works(): void
+    {
+        $this->postJson(route(RouteNames::CREATE_QUOTE_PROGRESS, [
+            'email' => 'daryna@jauntin.com',
+            'data' => ['excludedActivities' => true, 'averageDailyAttendance' => 40],
+        ], false), ['Accept' => 'application/json'])
+            ->assertStatus(201);
+    }
+
+    public function test_create_quote_progress_rejects_too_many_additional_emails(): void
+    {
+        $this->postJson(route(RouteNames::CREATE_QUOTE_PROGRESS, [
+            'email' => 'daryna@jauntin.com',
+            'additionalEmails' => ['a@jauntin.com', 'b@jauntin.com', 'c@jauntin.com', 'd@jauntin.com', 'e@jauntin.com'],
+            'data' => ['excludedActivities' => true, 'averageDailyAttendance' => 40],
+        ], false), ['Accept' => 'application/json'])
+            ->assertStatus(422);
+    }
+
+    public function test_create_quote_progress_rejects_duplicate_additional_emails(): void
+    {
+        $this->postJson(route(RouteNames::CREATE_QUOTE_PROGRESS, [
+            'email' => 'daryna@jauntin.com',
+            'additionalEmails' => ['second@jauntin.com', 'second@jauntin.com'],
+            'data' => ['excludedActivities' => true, 'averageDailyAttendance' => 40],
+        ], false), ['Accept' => 'application/json'])
+            ->assertStatus(422);
+    }
+
+    public function test_create_quote_progress_rejects_invalid_additional_email(): void
+    {
+        $this->postJson(route(RouteNames::CREATE_QUOTE_PROGRESS, [
+            'email' => 'daryna@jauntin.com',
+            'additionalEmails' => ['not-an-email'],
+            'data' => ['excludedActivities' => true, 'averageDailyAttendance' => 40],
+        ], false), ['Accept' => 'application/json'])
+            ->assertStatus(422);
+    }
+
     private function createQuoteProgress($data = []): QuoteProgress
     {
         $data = [

--- a/tests/Feature/Http/QuoteProgressControllerTest.php
+++ b/tests/Feature/Http/QuoteProgressControllerTest.php
@@ -49,6 +49,16 @@ class QuoteProgressControllerTest extends SavingQuoteTestCase
             ->assertStatus(422);
     }
 
+    public function test_get_quote_progress_without_additional_emails_returns_empty_array(): void
+    {
+        $quoteProgress = $this->createQuoteProgress();
+        $this->getJson(route(RouteNames::GET_QUOTE_PROGRESS, ['hash' => $quoteProgress->id], false))
+            ->assertStatus(200)
+            ->assertJson([
+                'data' => ['additionalEmails' => []],
+            ]);
+    }
+
     public function test_create_quote_progress(): void
     {
         $this->postJson(route(RouteNames::CREATE_QUOTE_PROGRESS, [

--- a/tests/Feature/Http/QuoteProgressControllerTest.php
+++ b/tests/Feature/Http/QuoteProgressControllerTest.php
@@ -126,6 +126,16 @@ class QuoteProgressControllerTest extends SavingQuoteTestCase
             ->assertStatus(422);
     }
 
+    public function test_create_quote_progress_rejects_additional_email_matching_primary_email(): void
+    {
+        $this->postJson(route(RouteNames::CREATE_QUOTE_PROGRESS, [
+            'email' => 'daryna@jauntin.com',
+            'additionalEmails' => ['daryna@jauntin.com'],
+            'data' => ['excludedActivities' => true, 'averageDailyAttendance' => 40],
+        ], false), ['Accept' => 'application/json'])
+            ->assertStatus(422);
+    }
+
     public function test_create_quote_progress_rejects_invalid_additional_email(): void
     {
         $this->postJson(route(RouteNames::CREATE_QUOTE_PROGRESS, [

--- a/tests/Unit/Models/QuoteProgressTest.php
+++ b/tests/Unit/Models/QuoteProgressTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use Illuminate\Support\Carbon;
+use Jauntin\SavingQuote\Models\QuoteProgress;
+use Tests\SavingQuoteTestCase;
+
+class QuoteProgressTest extends SavingQuoteTestCase
+{
+    public function test_additional_emails_is_cast_to_array_and_nullable(): void
+    {
+        $quoteProgress = new QuoteProgress([
+            'email' => 'primary@example.com',
+            'data' => ['key' => 'value'],
+            'expire_at' => Carbon::now()->addWeek(),
+            'additional_emails' => ['second@example.com', 'third@example.com'],
+        ]);
+        $quoteProgress->save();
+
+        $fresh = QuoteProgress::find($quoteProgress->id);
+
+        $this->assertSame(['second@example.com', 'third@example.com'], $fresh->additional_emails);
+    }
+
+    public function test_additional_emails_defaults_to_null_when_omitted(): void
+    {
+        $quoteProgress = new QuoteProgress([
+            'email' => 'primary@example.com',
+            'data' => ['key' => 'value'],
+            'expire_at' => Carbon::now()->addWeek(),
+        ]);
+        $quoteProgress->save();
+
+        $fresh = QuoteProgress::find($quoteProgress->id);
+
+        $this->assertNull($fresh->additional_emails);
+    }
+}

--- a/tests/Unit/Service/QuoteProgressServiceTest.php
+++ b/tests/Unit/Service/QuoteProgressServiceTest.php
@@ -39,6 +39,26 @@ class QuoteProgressServiceTest extends SavingQuoteTestCase
         $this->assertGreaterThan(Carbon::now(), $quoteProgress->expire_at);
     }
 
+    public function test_create_quote_progress_sends_mail_to_additional_emails(): void
+    {
+        Mail::fake();
+        Mail::shouldReceive('to')
+            ->once()
+            ->with(['test@example.com', 'second@example.com', 'third@example.com'])
+            ->andReturnSelf();
+        Mail::shouldReceive('queue')->once()->andReturnSelf();
+        $data = [
+            'email' => 'test@example.com',
+            'additionalEmails' => ['second@example.com', 'third@example.com'],
+            'data' => ['key' => 'value'],
+        ];
+        $this->mailable->shouldReceive('setQuoteProgress')->once()->andReturnSelf();
+
+        $quoteProgress = $this->service->create($data);
+
+        $this->assertEquals(['second@example.com', 'third@example.com'], $quoteProgress->additional_emails);
+    }
+
     public function test_create_quote_progress_without_mailable(): void
     {
         Mail::fake();

--- a/tests/Unit/Service/QuoteProgressServiceTest.php
+++ b/tests/Unit/Service/QuoteProgressServiceTest.php
@@ -3,80 +3,89 @@
 namespace Tests\Unit\Service;
 
 use Carbon\Carbon;
+use Illuminate\Mail\Mailable;
 use Illuminate\Support\Facades\Mail;
 use Jauntin\SavingQuote\Interfaces\QuoteProgressAwareMailable;
 use Jauntin\SavingQuote\Models\QuoteProgress;
 use Jauntin\SavingQuote\Service\QuoteProgressService;
-use Mockery\MockInterface;
+use Mockery;
 use Tests\SavingQuoteTestCase;
 
 class QuoteProgressServiceTest extends SavingQuoteTestCase
 {
-    private QuoteProgressService $service;
+    /** @var Mailable&QuoteProgressAwareMailable */
+    private $mailable;
 
-    private MockInterface&QuoteProgressAwareMailable $mailable;
+    private QuoteProgressService $service;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->mailable = $this->mock(QuoteProgressAwareMailable::class);
+        Mail::fake();
+        $this->mailable = Mockery::mock(Mailable::class, QuoteProgressAwareMailable::class)->makePartial();
+        $this->mailable->shouldReceive('setQuoteProgress')->andReturnSelf();
         $this->service = new QuoteProgressService('week', 1, $this->mailable);
     }
 
-    public function test_create_quote_progress(): void
+    public function test_create_saves_a_quote_progress_that_expires_in_the_future(): void
     {
-        Mail::fake();
-        Mail::shouldReceive('to')->once()->andReturnSelf();
-        Mail::shouldReceive('queue')->once()->andReturnSelf();
         $data = ['email' => 'test@example.com', 'data' => ['key' => 'value']];
-        $this->mailable->shouldReceive('setQuoteProgress')->once()->andReturnSelf();
 
         $quoteProgress = $this->service->create($data);
 
         $this->assertInstanceOf(QuoteProgress::class, $quoteProgress);
-        $this->assertEquals($data['email'], $quoteProgress->email);
-        $this->assertEquals($data['data'], $quoteProgress->data);
+        $this->assertTrue($quoteProgress->exists);
+        $this->assertEquals('test@example.com', $quoteProgress->email);
+        $this->assertEquals(['key' => 'value'], $quoteProgress->data);
+        $this->assertNull($quoteProgress->additional_emails);
         $this->assertGreaterThan(Carbon::now(), $quoteProgress->expire_at);
     }
 
-    public function test_create_quote_progress_sends_mail_to_additional_emails(): void
+    public function test_create_queues_mail_to_the_primary_email_only(): void
     {
-        Mail::fake();
-        Mail::shouldReceive('to')
-            ->once()
-            ->with(['test@example.com', 'second@example.com', 'third@example.com'])
-            ->andReturnSelf();
-        Mail::shouldReceive('queue')->once()->andReturnSelf();
+        $data = ['email' => 'test@example.com', 'data' => ['key' => 'value']];
+
+        $this->service->create($data);
+
+        Mail::assertQueued(fn (Mailable $mail) => $mail->hasTo('test@example.com')
+            && count($mail->to) === 1
+            && $mail->cc === []
+            && $mail->bcc === []);
+        Mail::assertQueuedCount(1);
+    }
+
+    public function test_create_queues_mail_to_the_primary_and_additional_emails(): void
+    {
         $data = [
             'email' => 'test@example.com',
             'additionalEmails' => ['second@example.com', 'third@example.com'],
             'data' => ['key' => 'value'],
         ];
-        $this->mailable->shouldReceive('setQuoteProgress')->once()->andReturnSelf();
 
         $quoteProgress = $this->service->create($data);
 
         $this->assertEquals(['second@example.com', 'third@example.com'], $quoteProgress->additional_emails);
+        Mail::assertQueued(fn (Mailable $mail) => $mail->hasTo('test@example.com')
+            && $mail->hasTo('second@example.com')
+            && $mail->hasTo('third@example.com')
+            && count($mail->to) === 3
+            && $mail->cc === []
+            && $mail->bcc === []);
+        Mail::assertQueuedCount(1);
     }
 
-    public function test_create_quote_progress_without_mailable(): void
+    public function test_create_without_a_mailable_does_not_send_mail(): void
     {
-        Mail::fake();
-
         $service = new QuoteProgressService('week', 1);
         $data = ['email' => 'test@example.com', 'data' => ['key' => 'value']];
 
         $quoteProgress = $service->create($data);
 
         $this->assertInstanceOf(QuoteProgress::class, $quoteProgress);
-        $this->assertEquals($data['email'], $quoteProgress->email);
-        $this->assertEquals($data['data'], $quoteProgress->data);
-        $this->assertGreaterThan(Carbon::now(), $quoteProgress->expire_at);
-
-        Mail::assertNotQueued(QuoteProgressAwareMailable::class);
+        Mail::assertNothingQueued();
     }
 
-    public function test_mark_as_opened(): void
+    public function test_mark_as_opened_sets_the_opened_at_timestamp(): void
     {
         $quoteProgress = new QuoteProgress([
             'email' => 'test@example.com',
@@ -87,8 +96,8 @@ class QuoteProgressServiceTest extends SavingQuoteTestCase
 
         $updatedQuote = $this->service->markAsOpened($quoteProgress);
 
-        $this->assertNotNull($updatedQuote->opened_at);
-        $this->assertInstanceOf(Carbon::class, $updatedQuote->opened_at);
         $this->assertEquals($quoteProgress->id, $updatedQuote->id);
+        $this->assertInstanceOf(Carbon::class, $updatedQuote->opened_at);
+        $this->assertNotNull($updatedQuote->fresh()->opened_at);
     }
 }


### PR DESCRIPTION
### What does this PR address?

Adds support for CC'ing additional email recipients when a quote progress is saved. Covers the full slice: schema, config, validation, mail sending, and API resource exposure.

### How does this PR address the issue?

- **Schema**: nullable `additional_emails` (array cast) column on `quote_progresses`.
- **Config**: new `saving-quote.max_additional_emails` (default 4, env `SAVING_QUOTE_MAX_ADDITIONAL_EMAILS`).
- **Validation**: `additionalEmails` accepted as an optional array on `QuoteProgressController@store`, capped at the configured max, each entry required/email/distinct.
- **Mail**: `QuoteProgressService::create` merges `additionalEmails` into the primary `email` when queuing the saved-quote mailable via `Mail::to($recipients)`.
- **API**: `QuoteResource` now exposes `additionalEmails` inside `data` (defaults to `[]` when none saved).

### Demo

`POST` to the quote progress endpoint with:
```json
{
  "email": "primary@example.com",
  "additionalEmails": ["cc1@example.com", "cc2@example.com"],
  "data": { ... }
}
```
Saved quote mail is sent to primary + both CCs; `GET` on the resulting quote returns `additionalEmails` in `data`.

### Manual testing instructions

1. Create a quote progress with `additionalEmails` omitted — confirm it saves, mail goes only to `email`, resource returns `additionalEmails: []`.
2. Create one with `additionalEmails` set (≤ configured max) — confirm all recipients receive the mail and resource reflects the array.
3. Create one exceeding `max_additional_emails`, with a duplicate email, or with a malformed email — confirm 422 validation errors.

### Pre-merge Checklist

- [ ] PR has been linked to an issue
- [x] Tests created or updated as necessary
- [ ] Author has manually tested the update
- [ ] Reviewer has manually tested the update
